### PR TITLE
Use concurrent.futures instead of multiprocessing

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,7 @@ commands =
     coverage erase
     coverage run -m pytest {posargs:tests}
     # TODO: 100%
-    coverage report --show-missing --fail-under 82
+    coverage report --show-missing --fail-under 84
     pre-commit install -f --install-hooks
     pre-commit run --all-files
 


### PR DESCRIPTION
This made a 7-15% improvement in cloning speed on asottile's repositories.

This makes sense, before it was making a process which then subprocessed -- now the first process is a thread instead.  Since most of that thread's work is spent in IO of the subprocess, it functions quite efficiently (the GIL doesn't get in the way).