### PR TITLE
tox.ini: use "venv" instead of "venv-{project}"

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -12,7 +12,7 @@ commands =
     pre-commit run --all-files
 
 [testenv:venv]
-envdir = venv-{[tox]project}
+envdir = venv
 commands =
 
 [pep8]


### PR DESCRIPTION
aactivator is set up for "venv", not "venv-all-repos".

I somewhat arbitrarily changed tox.ini to use "venv", I can instead change aactivator if you prefer the "venv-all-repos" name.