### PR TITLE
Add --output-paths for better scripting

### DIFF
--- a/all_repos/cli.py
+++ b/all_repos/cli.py
@@ -52,3 +52,13 @@ def add_repos_with_matches_arg(parser):
         '--repos-with-matches', action='store_true',
         help='only print repositories with matches.',
     )
+
+
+def add_output_paths_arg(parser):
+    parser.add_argument(
+        '--output-paths', action='store_true',
+        help=(
+            f'Use `{os.sep}` as a separator instead of `:` in outputs (often '
+            f'helpful for scripting).'
+        ),
+    )

--- a/all_repos/find_files.py
+++ b/all_repos/find_files.py
@@ -38,13 +38,14 @@ def find_files_repos_cli(config, pattern, *, use_color):
     return not repo_files
 
 
-def find_files_cli(config, pattern, *, use_color):
+def find_files_cli(config, pattern, *, output_paths, use_color):
+    sep = os.sep.encode() if output_paths else b':'
     repo_files = find_files(config, pattern)
     for repo, matching in repo_files.items():
         for filename in matching:
             sys.stdout.buffer.write(
                 color.fmtb(repo.encode(), color.BLUE_B, use_color=use_color) +
-                color.fmtb(b':', color.TURQUOISE, use_color=use_color) +
+                color.fmtb(sep, color.TURQUOISE, use_color=use_color) +
                 filename + b'\n',
             )
     return not repo_files
@@ -59,6 +60,7 @@ def main(argv=None):
     )
     cli.add_common_args(parser)
     cli.add_repos_with_matches_arg(parser)
+    cli.add_output_paths_arg(parser)
     parser.add_argument('pattern', help='the python regex to match.')
     args = parser.parse_args(argv)
 
@@ -66,7 +68,10 @@ def main(argv=None):
     if args.repos_with_matches:
         return find_files_repos_cli(config, args.pattern, use_color=args.color)
     else:
-        return find_files_cli(config, args.pattern, use_color=args.color)
+        return find_files_cli(
+            config, args.pattern,
+            output_paths=args.output_paths, use_color=args.color,
+        )
 
 
 if __name__ == '__main__':

--- a/all_repos/grep.py
+++ b/all_repos/grep.py
@@ -46,7 +46,8 @@ def repos_matching_cli(config, grep_args):
     return int(not matching)
 
 
-def grep_cli(config, grep_args, *, use_color):
+def grep_cli(config, grep_args, *, output_paths, use_color):
+    sep = os.sep.encode() if output_paths else b':'
     if use_color:
         grep_args = ('--color=always', *grep_args)
     try:
@@ -58,7 +59,7 @@ def grep_cli(config, grep_args, *, use_color):
         for line in stdout.splitlines():
             sys.stdout.buffer.write(
                 color.fmtb(repo_b, color.BLUE_B, use_color=use_color) +
-                color.fmtb(b':', color.TURQUOISE, use_color=use_color) +
+                color.fmtb(sep, color.TURQUOISE, use_color=use_color) +
                 line + b'\n',
             )
             sys.stdout.buffer.flush()
@@ -72,13 +73,16 @@ def main(argv=None):
     )
     cli.add_common_args(parser)
     cli.add_repos_with_matches_arg(parser)
+    cli.add_output_paths_arg(parser)
     args, rest = parser.parse_known_args(argv)
 
     config = load_config(args.config_filename)
     if args.repos_with_matches:
         return repos_matching_cli(config, rest)
     else:
-        return grep_cli(config, rest, use_color=args.color)
+        return grep_cli(
+            config, rest, output_paths=args.output_paths, use_color=args.color,
+        )
 
 
 if __name__ == '__main__':

--- a/tests/find_files_test.py
+++ b/tests/find_files_test.py
@@ -11,6 +11,15 @@ def test_find_files(file_config_files, capsys):
     )
 
 
+def test_find_files_output_paths(file_config_files, capsys):
+    assert not main((
+        '-C', str(file_config_files.cfg), '--color=never', '--output-paths',
+        r'\d',
+    ))
+    out, _ = capsys.readouterr()
+    assert out == '{}\n'.format(file_config_files.output_dir.join('repo2/f2'))
+
+
 def test_find_files_repos(file_config_files, capsys):
     assert not main((
         '-C', str(file_config_files.cfg), '--color=never', '--repos', r'\d',

--- a/tests/grep_test.py
+++ b/tests/grep_test.py
@@ -83,6 +83,16 @@ def test_grep_cli(file_config_files, capsys):
     assert out == ''
 
 
+def test_grep_cli_output_paths(file_config_files, capsys):
+    cmd = ('-C', str(file_config_files.cfg), '-l', '^OH', '--output-paths')
+    assert not main(cmd)
+    out, _ = capsys.readouterr()
+    assert out == '{}\n{}\n'.format(
+        file_config_files.output_dir.join('repo1/f'),
+        file_config_files.output_dir.join('repo2/f'),
+    )
+
+
 def _test_grep_color(file_config_files, capsys, *, args=()):
     ret = main(('-C', str(file_config_files.cfg), 'OHAI', *args))
     assert ret == 0


### PR DESCRIPTION
I find I often `all-repos-grep -l ... | sed 's|:|/|g' | xargs ...`

Now I can just `all-repos-grep --output-paths -l ... | xargs ...`