### PR TITLE
ListRepos: Support '--output-paths' option from cli

### DIFF
--- a/all_repos/list_repos.py
+++ b/all_repos/list_repos.py
@@ -1,4 +1,5 @@
 import argparse
+import os
 from typing import Optional
 from typing import Sequence
 
@@ -12,11 +13,15 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
         usage='all-repos-list-repos [options]',
     )
     cli.add_common_args(parser)
+    cli.add_output_paths_arg(parser)
     args = parser.parse_args(argv)
 
     config = load_config(args.config_filename)
     for repo in config.get_cloned_repos():
-        print(repo)
+        if args.output_paths:
+            print(os.path.join(config.output_dir, repo))
+        else:
+            print(repo)
     return 0
 
 

--- a/tests/list_repos_test.py
+++ b/tests/list_repos_test.py
@@ -5,3 +5,15 @@ def test_list_repos_main(file_config_files, capsys):
     assert not main(('--config-filename', str(file_config_files.cfg)))
     out, _ = capsys.readouterr()
     assert out == 'repo1\nrepo2\n'
+
+
+def test_list_repos_with_output_paths(file_config_files, capsys):
+    assert not main((
+        '--config-filename', str(file_config_files.cfg),
+        '--output-paths',
+    ))
+    out, _ = capsys.readouterr()
+    assert out == '{}\n{}\n'.format(
+        file_config_files.output_dir.join('repo1'),
+        file_config_files.output_dir.join('repo2'),
+    )


### PR DESCRIPTION
- using this option repos will printed with
configured output_dir

Signed-off-by: Andras Mitzki <mitzkia@gmail.com>

Resolves #93