### PR TITLE
TestGrepError: Update git error message 'fatal: no pattern given'

### DIFF
--- a/tests/grep_test.py
+++ b/tests/grep_test.py
@@ -122,4 +122,7 @@ def test_grep_error(file_config_files, capfd, args):
     assert ret == 128
     out, err = capfd.readouterr()
     assert out == ''
-    assert err == 'fatal: no pattern given.\n'
+    assert err in {
+        'fatal: no pattern given.\n',  # git < v2.19.0-rc0
+        'fatal: no pattern given\n',  # git >= v2.19.0-rc0
+    }


### PR DESCRIPTION
- with newer git (v2.19.1) this message skips the ending '.'
- this message has been changed in the past
https://github.com/git/git/commit/1a07e59c3e269418f3f5d186d166bf5ab5db6667

Signed-off-by: Andras Mitzki <mitzkia@gmail.com>

Resolves #94