### PR TITLE
Added delete_old config flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ all-repos
 
 Clone all your repositories and apply sweeping changes.
 
+
 ## Installation
 
 `pip install all-repos`
@@ -177,6 +178,8 @@ A configuration file looks roughly like this:
   Repository names which match this regex will be excluded.
 - `all_branches` (default `false`): whether to clone all of the branches or
   just the default upstream branch.
+- `delete_all` (default `true`): whether to delete repositories no longer available 
+  when running all-repos-clone
 
 ## Source modules
 

--- a/all_repos/clone.py
+++ b/all_repos/clone.py
@@ -145,4 +145,3 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
 
 if __name__ == '__main__':
     exit(main())
-

--- a/all_repos/clone.py
+++ b/all_repos/clone.py
@@ -122,8 +122,9 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
     filtered_repos = set(repos_filtered.items())
 
     # Remove old no longer cloned repositories
-    for path, _ in current_repos - filtered_repos:
-        _remove(config.output_dir, path)
+    if config.delete_old:
+        for path, _ in current_repos - filtered_repos:
+            _remove(config.output_dir, path)
 
     for path, remote in filtered_repos - current_repos:
         _init(config.output_dir, path, remote)
@@ -144,3 +145,4 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
 
 if __name__ == '__main__':
     exit(main())
+

--- a/all_repos/config.py
+++ b/all_repos/config.py
@@ -17,6 +17,7 @@ class Config(NamedTuple):
     push: Callable[[Any, str], None]
     push_settings: Any
     all_branches: bool
+    delete_old: bool
 
     def _path(self, *paths: str) -> str:
         return os.path.abspath(os.path.join(self.output_dir, *paths))
@@ -57,9 +58,11 @@ def load_config(filename: str) -> Config:
     include = re.compile(contents.get('include', ''))
     exclude = re.compile(contents.get('exclude', '^$'))
     all_branches = contents.get('all_branches', False)
+    delete_old = contents.get('delete_old', True)
     return Config(
         output_dir=output_dir, include=include, exclude=exclude,
         list_repos=source_module.list_repos, source_settings=source_settings,
         push=push_module.push, push_settings=push_settings,
         all_branches=all_branches,
+        delete_old=delete_old,
     )


### PR DESCRIPTION
Added a config variable 'delete_old', which acts only as a trigger for the local removal of repositories no longer available as remotes. 

I did this to protect myself from remote deletion, but might be worth keeping in the code base. The default; "delete_old": true, will not change behavior. 