### PR TITLE
github_api: use ssh_url instead of fixed base url

### DIFF
--- a/all_repos/github_api.py
+++ b/all_repos/github_api.py
@@ -44,12 +44,19 @@ def get_all(url: str, **kwargs: Any) -> List[Dict[str, Any]]:
     return ret
 
 
+def _strip_trailing_dot_git(ssh_url: str) -> str:
+    if ssh_url.endswith('.git'):
+        return ssh_url[:-1 * len('.git')]
+    else:
+        return ssh_url
+
+
 def filter_repos(
         repos: List[Dict[str, Any]], *,
         forks: bool, private: bool, collaborator: bool, archived: bool,
 ) -> Dict[str, str]:
     return {
-        repo['full_name']: 'git@github.com:{}'.format(repo['full_name'])
+        repo['full_name']: _strip_trailing_dot_git(repo['ssh_url'])
         for repo in repos
         if (
             (forks or not repo['fork']) and

--- a/tests/github_api_test.py
+++ b/tests/github_api_test.py
@@ -1,5 +1,6 @@
 import pytest
 
+from all_repos.github_api import _strip_trailing_dot_git
 from all_repos.github_api import better_repr
 from all_repos.github_api import get_all
 from testing.mock_http import FakeResponse
@@ -52,3 +53,25 @@ def test_get_all(mock_urlopen):
 
     ret = get_all('https://example.com/api')
     assert ret == ['page1_1', 'page1_2', 'page2_1', 'page2_2', 'page3_1']
+
+
+@pytest.mark.parametrize(
+    ('val', 'expected'),
+    (
+        ('', ''),
+        (
+            'git@github.com:sass/libsass-python',
+            'git@github.com:sass/libsass-python',
+        ),
+        (
+            'git@github.com:sass/libsass-python.git',
+            'git@github.com:sass/libsass-python',
+        ),
+        (
+            'git@github.com:.git/example',
+            'git@github.com:.git/example',
+        ),
+    ),
+)
+def test_strip_trailing_dot_git(val, expected):
+    assert _strip_trailing_dot_git(val) == expected


### PR DESCRIPTION
this makes sure we get the correct url for github enterprise repos that
use a custom domain. hopefully fixes #133