### PR TITLE
add missing FILENAMES argument to `all-repos-grep`

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,9 +70,13 @@ Sample invocations:
 - `all-repos-find-files --repos setup.py`: find all repositories containing
   a `setup.py`.
 
-### `all-repos-grep [options] [GIT_GREP_OPTIONS]`
+### `all-repos-grep [options] [GIT_GREP_OPTIONS] FILENAMES`
 
 Similar to a distributed `git grep ...`.
+
+Arguments:
+
+- `FILENAMES`: filenames glob (passed to `git ls-files`).
 
 Options:
 


### PR DESCRIPTION
cf documentation for `all-repos-sed`.