### PR TITLE
feat: add include_subgroups option to gitlab_org 

### DIFF
--- a/all_repos/clone.py
+++ b/all_repos/clone.py
@@ -27,7 +27,10 @@ def _get_current_state_helper(
     for direntry in os.scandir(path):
         if direntry.name == '.git':
             seen_git = True
-        elif direntry.is_dir():  # pragma: no branch (defensive)
+        elif (
+            direntry.is_dir() and
+            not direntry.name.startswith('.')
+        ):  # pragma: no branch (defensive)
             pths.append(direntry)
     if seen_git:
         yield path, git.remote(path)

--- a/all_repos/sed.py
+++ b/all_repos/sed.py
@@ -3,6 +3,7 @@ import functools
 import os.path
 import shlex
 import subprocess
+import sys
 from typing import Generator
 from typing import Optional
 from typing import Sequence
@@ -83,7 +84,14 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
         dash_r = ('-r',)
     else:
         dash_r = ()
-    sed_cmd = ('sed', '-i', *dash_r, args.expression)
+
+    inplace_ext: Tuple[str, ...]
+    if sys.platform == 'darwin':  # pragma: no cover
+        inplace_ext = ('',)
+    else:
+        inplace_ext = ()
+
+    sed_cmd = ('sed', '-i', *inplace_ext, *dash_r, args.expression)
     ls_files_cmd = ('git', 'ls-files', '-z', '--', args.filenames)
 
     msg = f'{_quote_cmd(ls_files_cmd)} | xargs -0 {_quote_cmd(sed_cmd)}'

--- a/all_repos/source/gitlab_org.py
+++ b/all_repos/source/gitlab_org.py
@@ -10,20 +10,18 @@ class Settings(NamedTuple):
     org: str
     base_url: str = 'https://gitlab.com/api/v4'
     archived: bool = False
+    with_shared: bool = False
+    include_subgroups: bool = False
 
     def __repr__(self) -> str:
         return hide_api_key_repr(self)
 
 
-LIST_REPOS_URL = (
-    '{settings.base_url}/groups/'
-    '{settings.org}/projects?with_shared=False'
-)
-
-
 def list_repos(settings: Settings) -> Dict[str, str]:
     repos = gitlab_api.get_all(
-        LIST_REPOS_URL.format(settings=settings),
+        f'{settings.base_url}/groups/{settings.org}/projects'
+        f'?with_shared={settings.with_shared}'
+        f'&include_subgroups={settings.include_subgroups}',
         headers={'Private-Token': settings.api_key},
     )
     return gitlab_api.filter_repos_from_settings(repos, settings)

--- a/tests/source/gitlab_org_test.py
+++ b/tests/source/gitlab_org_test.py
@@ -16,8 +16,8 @@ def _resource_json(name):
 @pytest.fixture
 def repos_response(mock_urlopen):
     mock_urlopen.side_effect = urlopen_side_effect({
-        'https://gitlab.com/api/v4/groups/ronny-test/'
-        'projects?with_shared=False': FakeResponse(
+        'https://gitlab.com/api/v4/groups/ronny-test/projects'
+        '?with_shared=False&include_subgroups=False': FakeResponse(
             json.dumps(_resource_json('org-listing')).encode(),
         ),
     })
@@ -39,5 +39,7 @@ def test_settings_repr():
         "    org='sass',\n"
         "    base_url='https://gitlab.com/api/v4',\n"
         '    archived=False,\n'
+        '    with_shared=False,\n'
+        '    include_subgroups=False,\n'
         ')'
     )


### PR DESCRIPTION
Features:
* Added option `include_subgroups` to `gitlab_org` source driver. Also, `with_shared` option moved to settings instead of hardcode to url path params. 

Fixes:
* Added filtering of dot directories scan on clone operation because of permissions:
```
19:24 /Volumes/projects all-repos ❯ ls -lahtr
total 48
-rw-r--r--@  1 m.ushanov  staff   6.0K  7 Apr 23:26 .DS_Store
drwx------   4 root       staff   128B 14 Jul 11:13 .Spotlight-V100
d-wx--x--t   3 root       wheel    96B 14 Jul 11:13 .Trashes
drwxr-xr-x   4 root       wheel   128B 18 Jul 14:46 ..
drwxr-xr-x   3 m.ushanov  staff    96B 20 Jul 17:02 infra
-rw-r--r--   1 m.ushanov  staff   5.3K 20 Jul 17:06 repos.json
drwxr-xr-x   9 m.ushanov  staff   288B 20 Jul 17:06 .
-rw-r--r--   1 m.ushanov  staff   5.3K 20 Jul 17:06 repos_filtered.json
drwx------  62 root       wheel   1.9K 20 Jul 17:06 .fseventsd
```
* Added empty extension to in-place sed command because it's required on darwin (bsd-like sed):
```
     -i extension
             Edit files in-place similarly to -I, but treat each file independently from other files.  In particular, line numbers in each file start at 1, the ``$'' address matches the last line
             of the current file, and address ranges are limited to the current file.  (See Sed Addresses.)  The net result is as though each file were edited by a separate sed instance.
``` 

```
       -i[SUFFIX], --in-place[=SUFFIX]

              edit files in place (makes backup if SUFFIX supplied)
```