### PR TITLE
Add Linux/Debian installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,15 @@ Clone all your repositories and apply sweeping changes.
 
 ## Installation
 
+### Windows and MacOS
+
 `pip install all-repos`
 
+### Linux
+
+When installing with pip (which can be installed with `sudo apt install python3-pip`) the `all-repos` command is not added to your bin file by default, so a prefix is required to allow you to easily utilize the tool from your command line.
+
+`sudo pip install --prefix /usr/local all-repos`
 
 ## CLI
 


### PR DESCRIPTION
For me the default `pip install all-repos` did not work out of the box on Pop_OS! Due to this I'm inclined to believe that this is likely the case for Ubuntu and other Debian based installations as well. 

If anyone else has had success with the pip install working out of the box I can certainly reformat my README addition to be a "If you're having issues with linux" type approach.