### PR TITLE
Pass `-h` through to `git grep` instead of invoking help

### DIFF
--- a/all_repos/grep.py
+++ b/all_repos/grep.py
@@ -86,6 +86,11 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
     parser = argparse.ArgumentParser(
         description='Similar to a distributed `git grep ...`.',
         usage='%(prog)s [options] [GIT_GREP_OPTIONS]',
+        add_help=False,
+    )
+    # Handle --help like normal, pass -h through to git grep
+    parser.add_argument(
+        '--help', action='help', help='show this help message and exit',
     )
     cli.add_common_args(parser)
     cli.add_repos_with_matches_arg(parser)

--- a/tests/grep_test.py
+++ b/tests/grep_test.py
@@ -82,6 +82,14 @@ def test_grep_cli(file_config_files, capsys):
     out, _ = capsys.readouterr()
     assert out == ''
 
+    ret = main(('-C', str(file_config_files.cfg), '-h', '^OH'))
+    assert ret == 0
+    out, _ = capsys.readouterr()
+    assert out == '{}:OHAI\n{}:OHELLO\n'.format(
+        file_config_files.output_dir.join('repo1'),
+        file_config_files.output_dir.join('repo2'),
+    )
+
 
 def test_grep_cli_output_paths(file_config_files, capsys):
     cmd = ('-C', str(file_config_files.cfg), '-l', '^OH', '--output-paths')


### PR DESCRIPTION
Pass the `-h` option straight through to `git grep` rather than treating it as a help option.

e.g.

```
$ all-repos-grep -h 'foo' '*.txt'
<normal output here>
```

Closes: #187