### PR TITLE
Fetch GitLab projects from subgroups

### DIFF
--- a/all_repos/source/gitlab_org.py
+++ b/all_repos/source/gitlab_org.py
@@ -18,7 +18,7 @@ class Settings(NamedTuple):
 
 LIST_REPOS_URL = (
     '{settings.base_url}/groups/'
-    '{settings.org}/projects?with_shared=False'
+    '{settings.org}/projects?with_shared=False&include_subgroups=true'
 )
 
 

--- a/tests/source/gitlab_org_test.py
+++ b/tests/source/gitlab_org_test.py
@@ -19,7 +19,7 @@ def _resource_json(name):
 def repos_response(mock_urlopen):
     mock_urlopen.side_effect = urlopen_side_effect({
         'https://gitlab.com/api/v4/groups/ronny-test/'
-        'projects?with_shared=False': FakeResponse(
+        'projects?with_shared=False&include_subgroups=true': FakeResponse(
             json.dumps(_resource_json('org-listing')).encode(),
         ),
     })


### PR DESCRIPTION
I've tested GitLab cloning and find out that it doesn't include projects from subgroups. I think it's important to fetch them as well.