### PR TITLE
autofixer: Support custom branch prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -504,6 +504,7 @@ Options:
 - `--limit LIMIT`: maximum number of repos to process (default: unlimited).
 - `--author AUTHOR`: override commit author.  This is passed directly to
   `git commit`.  An example: `--author='Herp Derp <herp.derp@umich.edu>'`.
+- `--branch-prefix PREFIX`: set branch prefix (default 'all-repos_autofix_').
 - `--repos [REPOS [REPOS ...]]`: run against specific repositories instead.
   This is especially useful with `xargs autofixer ... --repos`.  This can be
   used to specify repositories which are not managed by `all-repos`.

--- a/all_repos/autofix_lib.py
+++ b/all_repos/autofix_lib.py
@@ -59,6 +59,10 @@ def add_fixer_args(parser: argparse.ArgumentParser) -> None:
             'specify repositories which are not managed by `all-repos`.'
         ),
     )
+    parser.add_argument(
+        '--branch-prefix', type=str, default='all-repos_autofix_',
+        help='maximum number of repos to process (default: unlimited).',
+    )
 
 
 class Commit(NamedTuple):
@@ -73,12 +77,14 @@ class AutofixSettings(NamedTuple):
     limit: int | None
     dry_run: bool
     interactive: bool
+    branch_prefix: str
 
     @classmethod
     def from_cli(cls, args: Any) -> AutofixSettings:
         return cls(
             jobs=args.jobs, color=args.color, limit=args.limit,
             dry_run=args.dry_run, interactive=args.interactive,
+            branch_prefix=args.branch_prefix,
         )
 
 
@@ -227,7 +233,7 @@ def _fix_inner(
         autofix_settings: AutofixSettings,
 ) -> None:
     with repo_context(repo, use_color=autofix_settings.color):
-        branch_name = f'all-repos_autofix_{commit.branch_name}'
+        branch_name = f'{autofix_settings.branch_prefix}{commit.branch_name}'
         run('git', 'checkout', '--quiet', 'origin/HEAD', '-b', branch_name)
 
         apply_fix()

--- a/tests/autofix_lib_test.py
+++ b/tests/autofix_lib_test.py
@@ -210,6 +210,7 @@ def test_fix_dry_run_no_change(file_config_files, capfd):
         commit=autofix_lib.Commit('message!', 'test-branch', None),
         autofix_settings=autofix_lib.AutofixSettings(
             jobs=1, color=False, limit=None, dry_run=True, interactive=False,
+            branch_prefix='all-repos_autofix_',
         ),
     )
 
@@ -236,6 +237,7 @@ def test_fix_with_limit(file_config_files, capfd):
         commit=autofix_lib.Commit('message!', 'test-branch', None),
         autofix_settings=autofix_lib.AutofixSettings(
             jobs=1, color=False, limit=1, dry_run=True, interactive=False,
+            branch_prefix='all-repos_autofix_',
         ),
     )
 
@@ -259,6 +261,7 @@ def test_fix_interactive(file_config_files, capfd, mock_input):
         commit=autofix_lib.Commit('message!', 'test-branch', None),
         autofix_settings=autofix_lib.AutofixSettings(
             jobs=1, color=False, limit=None, dry_run=False, interactive=True,
+            branch_prefix='all-repos_autofix_',
         ),
     )
 
@@ -277,6 +280,7 @@ def test_autofix_makes_commits(file_config_files, capfd):
         commit=autofix_lib.Commit('message!', 'test-branch', 'A B <a@a.a>'),
         autofix_settings=autofix_lib.AutofixSettings(
             jobs=1, color=False, limit=None, dry_run=False, interactive=False,
+            branch_prefix='all-repos_autofix_',
         ),
     )
 
@@ -321,6 +325,7 @@ def test_fix_failing_check_no_changes(file_config_files, capfd):
         commit=autofix_lib.Commit('message!', 'test-branch', None),
         autofix_settings=autofix_lib.AutofixSettings(
             jobs=1, color=False, limit=None, dry_run=False, interactive=False,
+            branch_prefix='all-repos_autofix_',
         ),
     )
 
@@ -346,6 +351,7 @@ def test_noop_does_not_commit(file_config_files):
         commit=autofix_lib.Commit('message!', 'test-branch', None),
         autofix_settings=autofix_lib.AutofixSettings(
             jobs=1, color=False, limit=None, dry_run=False, interactive=False,
+            branch_prefix='all-repos_autofix_',
         ),
     )
     rev_after1 = testing.git.revparse(file_config_files.dir1)
@@ -365,6 +371,7 @@ def test_fix_non_default_branch(file_config_non_default):
         commit=autofix_lib.Commit('message!', 'test-branch', 'A B <a@a.a>'),
         autofix_settings=autofix_lib.AutofixSettings(
             jobs=1, color=False, limit=None, dry_run=False, interactive=False,
+            branch_prefix='all-repos_autofix_',
         ),
     )
 


### PR DESCRIPTION
Our policies only allow branches with certain prefixes