### PR TITLE
Correctly use gnu-sed on macos

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,13 +114,11 @@ Options:
 Similar to a distributed
 `git ls-files -z -- FILENAMES | xargs -0 sed -i EXPRESSION`.
 
-_note_: this assumes GNU sed. If you're on macOS, install `gnu-sed` with Homebrew:
+_note_: this assumes GNU sed. If you're on macOS, install `gnu-sed` with
+Homebrew, which will expose `gsed` executable:
 
 ```bash
 brew install gnu-sed
-
-# Add to .bashrc / .zshrc
-export PATH="$(brew --prefix)/opt/gnu-sed/libexec/gnubin:$PATH"
 ```
 
 Arguments:


### PR DESCRIPTION
- corrects gnu-sed installation instructions on macos, avoids asking to alter PATH as this might cause problems with other tools, including system ones
- uses `gsed` on macos
- display error message if `gnu-sed` is missing on macos

Related: #68