### PR TITLE
Support creating draft PRs for Github Pull Requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -477,11 +477,12 @@ branch.
 
 #### Optional `push_settings`
 
+- `base_url` (default: `https://api.github.com`) is the base URL to the Github
+  API to use (for Github Enterprise support set this to `https://{your_domain}/api/v3`).
+- `draft` (default: `false`) if true will open the pull request as a draft.
 - `fork` (default: `false`): (if applicable) a fork will be created and pushed
   to instead of the upstream repository.  The pull request will then be made
   to the upstream repository.
-- `base_url` (default: `https://api.github.com`) is the base URL to the Github
-  API to use (for Github Enterprise support set this to `https://{your_domain}/api/v3`).
 
 ### `all_repos.push.bitbucket_server_pull_request`
 

--- a/all_repos/push/github_pull_request.py
+++ b/all_repos/push/github_pull_request.py
@@ -17,6 +17,7 @@ class Settings(NamedTuple):
     base_url: str = 'https://api.github.com'
     api_key: str | None = None
     api_key_env: str | None = None
+    draft: bool = False
 
     # TODO: https://github.com/python/mypy/issues/8543
     def __repr__(self) -> str:
@@ -56,6 +57,7 @@ def make_pull_request(
         'body': body.decode().strip(),
         'base': autofix_lib.target_branch(),
         'head': head,
+        'draft': settings.draft,
     }).encode()
 
     return github_api.req(

--- a/tests/push/github_pull_request_test.py
+++ b/tests/push/github_pull_request_test.py
@@ -50,6 +50,7 @@ def test_github_pull_request(mock_urlopen, fake_github_repo):
     assert data['title'] == 'This is a commit message'
     assert data['body'] == 'Here is some more information!'
     assert data['head'] == 'feature'
+    assert data['draft'] is False
 
 
 @pytest.fixture
@@ -96,5 +97,6 @@ def test_settings_repr():
         "    base_url='https://api.github.com',\n"
         '    api_key=...,\n'
         '    api_key_env=None,\n'
+        '    draft=False,\n'
         ')'
     )

--- a/tests/util_test.py
+++ b/tests/util_test.py
@@ -31,6 +31,7 @@ def test_hide_api_key_repr():
         "    base_url='https://api.github.com',\n"
         '    api_key=...,\n'
         '    api_key_env=None,\n'
+        '    draft=False,\n'
         ')'
     )
 


### PR DESCRIPTION
Resolves https://github.com/asottile/all-repos/issues/350

[Github API](https://docs.github.com/en/rest/pulls/pulls?apiVersion=2022-11-28#create-a-pull-request--parameters) supports a "draft" boolean. 

We can follow the same pattern as AzDO and use the settings "draft" boolean and pass to the api /pulls request.

Submitting a Pull Request now
