### PR TITLE
Adding the option `--repos-without-matches`

### DIFF
--- a/all_repos/cli.py
+++ b/all_repos/cli.py
@@ -61,6 +61,13 @@ def add_repos_with_matches_arg(parser: ParserType) -> None:
     )
 
 
+def add_repos_without_matches_arg(parser: ParserType) -> None:
+    parser.add_argument(
+        '--repos-without-matches', action='store_true',
+        help='only print repositories without matches.',
+    )
+
+
 def add_output_paths_arg(parser: ParserType) -> None:
     parser.add_argument(
         '--output-paths', action='store_true',

--- a/all_repos/find_files.py
+++ b/all_repos/find_files.py
@@ -74,6 +74,7 @@ def main(argv: Sequence[str] | None = None) -> int:
     )
     cli.add_common_args(parser)
     cli.add_repos_with_matches_arg(parser)
+    cli.add_repos_without_matches_arg(parser)
     cli.add_output_paths_arg(parser)
     parser.add_argument('pattern', help='the python regex to match.')
     args = parser.parse_args(argv)

--- a/all_repos/grep.py
+++ b/all_repos/grep.py
@@ -43,6 +43,7 @@ def grep(config: Config, grep_args: Sequence[str]) -> dict[str, bytes]:
 def repos_matching(config: Config, grep_args: Sequence[str]) -> set[str]:
     return set(grep(config, ('--quiet', *grep_args)))
 
+
 def repos_not_matching(config: Config, grep_args: Sequence[str]) -> set[str]:
     grep_ret = set(grep(config, ('--quiet', *grep_args)))
     repos = [os.path.join(config.output_dir, repo) for repo in config.get_cloned_repos()]

--- a/tests/grep_test.py
+++ b/tests/grep_test.py
@@ -8,7 +8,8 @@ import pytest
 from all_repos.config import load_config
 from all_repos.grep import grep
 from all_repos.grep import main
-from all_repos.grep import repos_matching, repos_not_matching
+from all_repos.grep import repos_matching
+from all_repos.grep import repos_not_matching
 
 
 def test_repos_matching(file_config_files):
@@ -70,7 +71,6 @@ def test_repos_not_matching_cli(file_config_files, capsys):
     assert ret == 1
     out, _ = capsys.readouterr()
     assert out == ''
-
 
     ret = main((
         '-C', str(file_config_files.cfg), '--repos-without-matches', 'OHAI',


### PR DESCRIPTION
`--repos-without-matches` returns all repositories not containing a match. It is the inverse of what `--repos-with-matches` returns. Example `all-repos-grep some-text-not-in-repos --repos-without-matches`.

@asottile thanks for all the software you write!

Not sure if this is something you have wanted or needed. I will say I did add `repos-without-matches` as an option to `all-repos-find-files` but it isn't returning repositories not containing a searched file e.g.: `all-repos-find-files .gitignore --repos-without-matches`.