### PR TITLE
support multiple filename args to all-repos-sed

### DIFF
--- a/all_repos/sed.py
+++ b/all_repos/sed.py
@@ -69,7 +69,8 @@ def main(argv: Sequence[str] | None = None) -> int:
         'expression', help='sed program. For example: `s/hi/hello/g`.',
     )
     parser.add_argument(
-        'filenames', help='filenames glob (passed to `git ls-files`).',
+        'filenames', nargs='+',
+        help='filenames glob (passed to `git ls-files`).',
     )
     args = parser.parse_args(argv)
 
@@ -80,7 +81,7 @@ def main(argv: Sequence[str] | None = None) -> int:
     else:
         dash_r = ()
     sed_cmd = ('sed', '-i', *dash_r, args.expression)
-    ls_files_cmd = ('git', 'ls-files', '-z', '--', args.filenames)
+    ls_files_cmd = ('git', 'ls-files', '-z', '--', *args.filenames)
 
     msg = f'{shlex.join(ls_files_cmd)} | xargs -0 {shlex.join(sed_cmd)}'
     msg = args.commit_msg or msg

--- a/tests/sed_test.py
+++ b/tests/sed_test.py
@@ -41,3 +41,17 @@ def test_main_custom_file_pattern(file_config_files):
     assert file_config_files.dir1.join('f').read() == 'OHAI\n'
     assert file_config_files.dir1.join('g').read() == 'OHIE\n'
     assert file_config_files.dir2.join('f').read() == 'OHELLO\n'
+
+
+def test_main_multiple_file_pattern(file_config_files):
+    write_file_commit(file_config_files.dir1, 'g', 'OHAI\n')
+    write_file_commit(file_config_files.dir1, 'h', 'OHAI\n')
+    clone.main(('--config-filename', str(file_config_files.cfg)))
+    assert not main((
+        '--config-filename', str(file_config_files.cfg),
+        's/AI/IE/g', 'g', 'f',
+    ))
+    assert file_config_files.dir1.join('f').read() == 'OHIE\n'
+    assert file_config_files.dir1.join('g').read() == 'OHIE\n'
+    assert file_config_files.dir1.join('h').read() == 'OHAI\n'
+    assert file_config_files.dir2.join('f').read() == 'OHELLO\n'


### PR DESCRIPTION
Supplying multiple filenames to all-repos-sed errors with `all-repos-sed: error: unrecognized arguments:` - which doesn't seem like the expected behaviour as `git ls-files` is perfectly fine with several filenames.