### PR TITLE
Add more optional push settings for GitLab PRs

### DIFF
--- a/README.md
+++ b/README.md
@@ -514,6 +514,11 @@ Pushes the branch to `origin` and then creates a GitLab pull request for the bra
     - We need the scope: `write_repository`.
 - `api_key_env`: alternatively API key can also be passed via an environment variable
 
+#### Optional `push_settings`
+
+- `draft` (default: `false`) if true will open the pull request as a draft.
+    - If `true`, the prefix `Draft` will be added to the title.
+
 ### `all_repos.push.readonly`
 
 Does nothing.

--- a/README.md
+++ b/README.md
@@ -518,6 +518,7 @@ Pushes the branch to `origin` and then creates a GitLab pull request for the bra
 
 - `draft` (default: `false`) if true will open the pull request as a draft.
     - If `true`, the prefix `Draft` will be added to the title.
+- `assignee_ids` (default: `None`): the IDs (integer) of the users to assign the merge request to.
 
 ### `all_repos.push.readonly`
 

--- a/all_repos/push/gitlab_pull_request.py
+++ b/all_repos/push/gitlab_pull_request.py
@@ -25,6 +25,7 @@ class Settings(NamedTuple):
     api_key: str | None = None
     api_key_env: str | None = None
     draft: bool = False
+    assignee_ids: list[int] | None = None
 
     def __repr__(self) -> str:
         return hide_api_key_repr(self)
@@ -65,6 +66,7 @@ def push(settings: Settings, branch_name: str) -> None:
         'title': mr_title,
         'description': body.decode().strip(),
         'remove_source_branch': True,
+        'assignee_ids': settings.assignee_ids,
     }).encode()
 
     resp = gitlab_api.req(

--- a/all_repos/push/gitlab_pull_request.py
+++ b/all_repos/push/gitlab_pull_request.py
@@ -12,12 +12,19 @@ from all_repos.github_api import _strip_trailing_dot_git
 from all_repos.util import hide_api_key_repr
 from all_repos.util import load_api_key
 
+DRAFT_PREFIX = 'Draft:'
+"""GitLab treats merge requests with a prefix `Draft:` as drafts.
+
+See also https://forum.gitlab.com/t/creating-draft-mr-with-the-api/55019
+"""
+
 
 class Settings(NamedTuple):
     base_url: str = 'https://gitlab.com/api/v4'
     fork: bool = False
     api_key: str | None = None
     api_key_env: str | None = None
+    draft: bool = False
 
     def __repr__(self) -> str:
         return hide_api_key_repr(self)
@@ -47,10 +54,15 @@ def push(settings: Settings, branch_name: str) -> None:
     title = subprocess.check_output(('git', 'log', '-1', '--format=%s'))
     body = subprocess.check_output(('git', 'log', '-1', '--format=%b'))
 
+    mr_title = title.decode().strip()
+    if settings.draft:
+        # Avoid duplicate draft prefixes
+        mr_title = f"{DRAFT_PREFIX} {mr_title.removeprefix(DRAFT_PREFIX)}"
+
     data = json.dumps({
         'source_branch': head,
         'target_branch': autofix_lib.target_branch(),
-        'title': title.decode().strip(),
+        'title': mr_title,
         'description': body.decode().strip(),
         'remove_source_branch': True,
     }).encode()

--- a/tests/push/gitlab_pull_request_test.py
+++ b/tests/push/gitlab_pull_request_test.py
@@ -86,5 +86,6 @@ def test_settings_repr():
         '    api_key=...,\n'
         '    api_key_env=None,\n'
         '    draft=False,\n'
+        '    assignee_ids=None,\n'
         ')'
     )

--- a/tests/push/gitlab_pull_request_test.py
+++ b/tests/push/gitlab_pull_request_test.py
@@ -83,9 +83,8 @@ def test_settings_repr():
         'Settings(\n'
         "    base_url='https://gitlab.com/api/v4',\n"
         '    fork=False,\n'
-
         '    api_key=...,\n'
-
         '    api_key_env=None,\n'
+        '    draft=False,\n'
         ')'
     )


### PR DESCRIPTION
* Add optional setting `draft` to GitLab PRs
* Add optional setting `assignee_ids` to GitLab PRs

See also
* API docs: https://docs.gitlab.com/api/merge_requests/#create-mr
* Draft PR: https://forum.gitlab.com/t/creating-draft-mr-with-the-api/55019