### PR TITLE
Add Bitbucket repo filtering with queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -350,6 +350,12 @@ Clones all repositories available to a user on Bitbucket Cloud.
     - Create an application password within your [account settings](https://bitbucket.org/account/admin/app-passwords).
     - We need the scope: Repositories -> Read
 
+#### Optional `source_settings`
+
+- `query` (default `''`): the query used to filter Bitbucket repositories, as described in the
+  [Bitbucket documentation](https://developer.atlassian.com/cloud/bitbucket/rest/intro/#querying).
+- `include_workspace` (default `True`): whether to include or not the namespace
+  in the pulled repo path.
 
 ### `all_repos.source.bitbucket_server`
 

--- a/all_repos/source/bitbucket.py
+++ b/all_repos/source/bitbucket.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
 import base64
-from typing import NamedTuple
 import urllib.parse
+from typing import NamedTuple
 
 from all_repos import bitbucket_api
 from all_repos.util import hide_api_key_repr

--- a/all_repos/source/bitbucket.py
+++ b/all_repos/source/bitbucket.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import base64
 from typing import NamedTuple
+import urllib.parse
 
 from all_repos import bitbucket_api
 from all_repos.util import hide_api_key_repr
@@ -24,9 +25,10 @@ class Settings(NamedTuple):
 
 
 def list_repos(settings: Settings) -> dict[str, str]:
+    query = urllib.parse.quote_plus(settings.query)
     repos = bitbucket_api.get_all(
         'https://api.bitbucket.org/2.0/repositories'
-        f'?pagelen=100&role=member&q={settings.query}',
+        f'?pagelen=100&role=member&q={query}',
         headers={'Authorization': f'Basic {settings.auth}'},
     )
 

--- a/all_repos/source/bitbucket.py
+++ b/all_repos/source/bitbucket.py
@@ -25,12 +25,13 @@ class Settings(NamedTuple):
 
 def list_repos(settings: Settings) -> dict[str, str]:
     repos = bitbucket_api.get_all(
-        f'https://api.bitbucket.org/2.0/repositories?pagelen=100&role=member&q={settings.query}',
+        'https://api.bitbucket.org/2.0/repositories'
+        f'?pagelen=100&role=member&q={settings.query}',
         headers={'Authorization': f'Basic {settings.auth}'},
     )
 
-    path_name_key = 'full_name' if settings.include_workspace else 'slug'
+    key = 'full_name' if settings.include_workspace else 'slug'
     return {
-        repo[path_name_key]: 'git@bitbucket.org:{}.git'.format(repo['full_name'])
+        repo[key]: 'git@bitbucket.org:{}.git'.format(repo['full_name'])
         for repo in repos
     }

--- a/all_repos/source/bitbucket.py
+++ b/all_repos/source/bitbucket.py
@@ -11,6 +11,7 @@ class Settings(NamedTuple):
     username: str
     app_password: str
     query: str = ''
+    include_workspace: bool = True
 
     @property
     def auth(self) -> str:
@@ -28,7 +29,8 @@ def list_repos(settings: Settings) -> dict[str, str]:
         headers={'Authorization': f'Basic {settings.auth}'},
     )
 
+    path_name_key = 'full_name' if settings.include_workspace else 'slug'
     return {
-        repo['full_name']: 'git@bitbucket.org:{}.git'.format(repo['full_name'])
+        repo[path_name_key]: 'git@bitbucket.org:{}.git'.format(repo['full_name'])
         for repo in repos
     }

--- a/all_repos/source/bitbucket.py
+++ b/all_repos/source/bitbucket.py
@@ -10,6 +10,7 @@ from all_repos.util import hide_api_key_repr
 class Settings(NamedTuple):
     username: str
     app_password: str
+    query: str = ''
 
     @property
     def auth(self) -> str:
@@ -23,7 +24,7 @@ class Settings(NamedTuple):
 
 def list_repos(settings: Settings) -> dict[str, str]:
     repos = bitbucket_api.get_all(
-        'https://api.bitbucket.org/2.0/repositories?pagelen=100&role=member',
+        f'https://api.bitbucket.org/2.0/repositories?pagelen=100&role=member&q={settings.query}',
         headers={'Authorization': f'Basic {settings.auth}'},
     )
 

--- a/tests/source/bitbucket_test.py
+++ b/tests/source/bitbucket_test.py
@@ -17,7 +17,10 @@ def _resource_json():
 
 @pytest.fixture
 def repos_response(mock_urlopen):
-    url = 'https://api.bitbucket.org/2.0/repositories?pagelen=100&role=member&q='
+    url = (
+        'https://api.bitbucket.org/2.0/repositories'
+        '?pagelen=100&role=member&q='
+    )
     mock_urlopen.side_effect = urlopen_side_effect({
         url: FakeResponse(json.dumps(_resource_json()).encode()),
     })
@@ -31,6 +34,7 @@ def test_list_repos():
         'fake_org/fake_repo': 'git@bitbucket.org:fake_org/fake_repo.git',
     }
 
+
 @pytest.mark.usefixtures('repos_response')
 def test_list_repos_without_workspace():
     settings = Settings('cool_user', 'app_password', include_workspace=False)
@@ -38,6 +42,7 @@ def test_list_repos_without_workspace():
     assert ret == {
         'fake_repo': 'git@bitbucket.org:fake_org/fake_repo.git',
     }
+
 
 def test_settings_repr():
     assert repr(Settings('cool_user', 'app_password')) == (

--- a/tests/source/bitbucket_test.py
+++ b/tests/source/bitbucket_test.py
@@ -17,7 +17,7 @@ def _resource_json():
 
 @pytest.fixture
 def repos_response(mock_urlopen):
-    url = 'https://api.bitbucket.org/2.0/repositories?pagelen=100&role=member'
+    url = 'https://api.bitbucket.org/2.0/repositories?pagelen=100&role=member&q='
     mock_urlopen.side_effect = urlopen_side_effect({
         url: FakeResponse(json.dumps(_resource_json()).encode()),
     })
@@ -31,11 +31,20 @@ def test_list_repos():
         'fake_org/fake_repo': 'git@bitbucket.org:fake_org/fake_repo.git',
     }
 
+@pytest.mark.usefixtures('repos_response')
+def test_list_repos_without_workspace():
+    settings = Settings('cool_user', 'app_password', include_workspace=False)
+    ret = list_repos(settings)
+    assert ret == {
+        'fake_repo': 'git@bitbucket.org:fake_org/fake_repo.git',
+    }
 
 def test_settings_repr():
     assert repr(Settings('cool_user', 'app_password')) == (
         'Settings(\n'
         "    username='cool_user',\n"
         '    app_password=...,\n'
+        '    query=\'\',\n'
+        '    include_workspace=True,\n'
         ')'
     )


### PR DESCRIPTION
- Add optional `query` option to filter repositories from the Bitbucket API
- Add optional `include_workspace` option to allow excluding the workspace name in pulled repos

I added the filtering as a URL parameter instead of adding a `filter_repos` function to allow more flexibility.
I think it could also make sense to generalize the `include_workspace` option as a top level option.