### PR TITLE
allow an interrupted `all-repos-clone` to continue by tagging output with `.all-repos`

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,6 +202,7 @@ follows:
 
 ```
 output/
++--- .all-repos
 +--- repos.json
 +--- repos_filtered.json
 +--- {repo_key1}/
@@ -237,6 +238,7 @@ Clones all repositories available to a user on github.
 
 ```
 output/
++--- .all-repos
 +--- repos.json
 +--- repos_filtered.json
 +--- {username1}/
@@ -331,6 +333,7 @@ configured here in order to query that API.
 
 ```
 output/
++--- .all-repos
 +--- repos.json
 +--- repos_filtered.json
 +--- {repo_name1}.git/
@@ -372,6 +375,7 @@ Clones all repositories available to a user on Bitbucket Server.
 
 ```
 output/
++--- .all-repos
 +--- repos.json
 +--- repos_filtered.json
 +--- {username1}/
@@ -403,6 +407,7 @@ Clones all repositories from an organization on gitlab.
 
 ```
 output/
++--- .all-repos
 +--- repos.json
 +--- repos_filtered.json
 +--- {org}/

--- a/all_repos/clone.py
+++ b/all_repos/clone.py
@@ -138,6 +138,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         f.write(json.dumps(repos))
     with open(config.repos_filtered_path, 'w') as f:
         f.write(json.dumps(repos_filtered))
+    open(os.path.join(config.output_dir, '.all-repos'), 'w').close()
     return 0
 
 

--- a/all_repos/config.py
+++ b/all_repos/config.py
@@ -53,6 +53,9 @@ def _check_output_dir(output_dir: str) -> None:
         if not contents:  # empty dir is ok!
             return
 
+        if '.all-repos' in contents:
+            return
+
         if not (
                 contents >= REPOS_JSON_FILES and
                 all(

--- a/tests/clone_test.py
+++ b/tests/clone_test.py
@@ -137,3 +137,19 @@ def test_it_sorts_filtered_repos(file_config):
     repos_filtered = file_config.output_dir.join('repos_filtered.json')
     repos_filtered = json.loads(repos_filtered.read())
     assert sorted(repos_filtered) == list(repos_filtered)
+
+
+def test_it_creates_marker_file(file_config):
+    assert not main(('--config-file', str(file_config.cfg)))
+    assert file_config.output_dir.join('.all-repos').exists()
+
+
+def test_it_recreates_marker_file(file_config):
+    assert not main(('--config-file', str(file_config.cfg)))
+
+    # remove marker file, to test if it will be recreated after the next run
+    # this simulates run for existing setups prior to introducing marker file
+    file_config.output_dir.join('.all-repos').remove()
+
+    assert not main(('--config-file', str(file_config.cfg)))
+    assert file_config.output_dir.join('.all-repos').exists()


### PR DESCRIPTION
resolves #377