### PR TITLE
Add support for GitHub HTTP cloning

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,6 +232,7 @@ Clones all repositories available to a user on github.
 - `archived` (default: `false`): whether to include archived repositories.
 - `base_url` (default: `https://api.github.com`) is the base URL to the Github
   API to use (for Github Enterprise support set this to `https://{your_domain}/api/v3`).
+- `ssh` (default: `true`): whether to use SSH to clone the repo (in place of HTTP)
 
 #### Directory location
 
@@ -268,6 +269,7 @@ Clones all repositories forked from a repository on github.
 - `archived` (default: `false`): whether to include archived repositories.
 - `base_url` (default: `https://api.github.com`) is the base URL to the Github
   API to use (for Github Enterprise support set this to `https://{your_domain}/api/v3`).
+- `ssh` (default: `true`): whether to use SSH to clone the repo (in place of HTTP)
 
 #### Directory location
 
@@ -298,6 +300,7 @@ Clones all repositories from an organization on github.
 - `archived` (default: `false`): whether to include archived repositories.
 - `base_url` (default: `https://api.github.com`) is the base URL to the Github
   API to use (for Github Enterprise support set this to `https://{your_domain}/api/v3`).
+- `ssh` (default: `true`): whether to use SSH to clone the repo (in place of HTTP)
 
 #### Directory location
 

--- a/README.md
+++ b/README.md
@@ -232,7 +232,7 @@ Clones all repositories available to a user on github.
 - `archived` (default: `false`): whether to include archived repositories.
 - `base_url` (default: `https://api.github.com`) is the base URL to the Github
   API to use (for Github Enterprise support set this to `https://{your_domain}/api/v3`).
-- `ssh` (default: `true`): whether to use SSH to clone the repo (in place of HTTP)
+- `ssh` (default: `true`): whether to use SSH to clone the repo (rather than HTTP)
 
 #### Directory location
 
@@ -269,7 +269,7 @@ Clones all repositories forked from a repository on github.
 - `archived` (default: `false`): whether to include archived repositories.
 - `base_url` (default: `https://api.github.com`) is the base URL to the Github
   API to use (for Github Enterprise support set this to `https://{your_domain}/api/v3`).
-- `ssh` (default: `true`): whether to use SSH to clone the repo (in place of HTTP)
+- `ssh` (default: `true`): whether to use SSH to clone the repo (rather than HTTP)
 
 #### Directory location
 
@@ -300,7 +300,7 @@ Clones all repositories from an organization on github.
 - `archived` (default: `false`): whether to include archived repositories.
 - `base_url` (default: `https://api.github.com`) is the base URL to the Github
   API to use (for Github Enterprise support set this to `https://{your_domain}/api/v3`).
-- `ssh` (default: `true`): whether to use SSH to clone the repo (in place of HTTP)
+- `ssh` (default: `true`): whether to use SSH to clone the repo (rather than HTTP)
 
 #### Directory location
 

--- a/all_repos/github_api.py
+++ b/all_repos/github_api.py
@@ -52,10 +52,13 @@ def _strip_trailing_dot_git(ssh_url: str) -> str:
 
 def filter_repos(
         repos: list[dict[str, Any]], *,
+        ssh: bool,
         forks: bool, private: bool, collaborator: bool, archived: bool,
 ) -> dict[str, str]:
     return {
-        repo['full_name']: _strip_trailing_dot_git(repo['ssh_url'])
+        repo['full_name']: _strip_trailing_dot_git(
+            repo['ssh_url' if ssh else 'clone_url'],
+        )
         for repo in repos
         if (
             (forks or not repo['fork']) and

--- a/all_repos/source/github.py
+++ b/all_repos/source/github.py
@@ -16,6 +16,7 @@ class Settings(NamedTuple):
     base_url: str = 'https://api.github.com'
     api_key: str | None = None
     api_key_env: str | None = None
+    ssh: bool = True
 
     # TODO: https://github.com/python/mypy/issues/8543
     def __repr__(self) -> str:
@@ -29,6 +30,7 @@ def list_repos(settings: Settings) -> dict[str, str]:
     )
     return github_api.filter_repos(
         repos,
+        ssh=settings.ssh,
         forks=settings.forks,
         private=settings.private,
         collaborator=settings.collaborator,

--- a/all_repos/source/github_forks.py
+++ b/all_repos/source/github_forks.py
@@ -16,6 +16,7 @@ class Settings(NamedTuple):
     base_url: str = 'https://api.github.com'
     api_key: str | None = None
     api_key_env: str | None = None
+    ssh: bool = True
 
     # TODO: https://github.com/python/mypy/issues/8543
     def __repr__(self) -> str:
@@ -37,6 +38,7 @@ def list_repos(settings: Settings) -> dict[str, str]:
 
     return github_api.filter_repos(
         repos,
+        ssh=settings.ssh,
         forks=settings.forks,
         private=settings.private,
         collaborator=settings.collaborator,

--- a/all_repos/source/github_org.py
+++ b/all_repos/source/github_org.py
@@ -16,6 +16,7 @@ class Settings(NamedTuple):
     base_url: str = 'https://api.github.com'
     api_key: str | None = None
     api_key_env: str | None = None
+    ssh: bool = True
 
     # TODO: https://github.com/python/mypy/issues/8543
     def __repr__(self) -> str:
@@ -29,6 +30,7 @@ def list_repos(settings: Settings) -> dict[str, str]:
     )
     return github_api.filter_repos(
         repos,
+        ssh=settings.ssh,
         forks=settings.forks,
         private=settings.private,
         collaborator=settings.collaborator,

--- a/tests/source/github_forks_test.py
+++ b/tests/source/github_forks_test.py
@@ -49,5 +49,6 @@ def test_settings_repr():
         "    base_url='https://api.github.com',\n"
         '    api_key=...,\n'
         '    api_key_env=None,\n'
+        '    ssh=True,\n'
         ')'
     )

--- a/tests/source/github_org_test.py
+++ b/tests/source/github_org_test.py
@@ -38,5 +38,6 @@ def test_settings_repr():
         "    base_url='https://api.github.com',\n"
         '    api_key=...,\n'
         '    api_key_env=None,\n'
+        '    ssh=True,\n'
         ')'
     )

--- a/tests/source/github_test.py
+++ b/tests/source/github_test.py
@@ -75,6 +75,7 @@ def test_settings_repr():
         "    base_url='https://api.github.com',\n"
         '    api_key=...,\n'
         '    api_key_env=None,\n'
+        '    ssh=True,\n'
         ')'
     )
 

--- a/tests/util_test.py
+++ b/tests/util_test.py
@@ -32,6 +32,7 @@ def test_hide_api_key_repr():
         '    api_key=...,\n'
         '    api_key_env=None,\n'
         '    draft=False,\n'
+        "    push='origin',\n"
         ')'
     )
 


### PR DESCRIPTION
This PR does two things:
1. Fix `push.github_pull_request` to allow HTTP remotes (besides SSH remotes)
  a. Originally contributed in #125 by @palikar
2. Add an `ssh` boolean option to `source.github`, `source.github_forks`, and `source.github_org`, that clones the repo using its HTTP URL instead of its SSH URL (set to SSH by default).

I believe this PR solves the reason you closed #125 (https://github.com/asottile/all-repos/pull/125#issuecomment-627411844), because it adds this functionality to the included `source.github*` sources.

To give some context to why I personally would like this (and to respond to https://github.com/asottile/all-repos/issues/119#issuecomment-568058067), I do my GitHub cloning via [git-credential-manager](https://github.com/git-ecosystem/git-credential-manager), which stores the credentials *at least more safely than putting them in plaintext in `~/.git-credentials`*. I do not wish to switch to using SSH keys, and I think that users should have the ability to use the HTTP ([which is officially recommended](https://docs.github.com/en/repositories/creating-and-managing-repositories/cloning-a-repository)) method of cloning repos.