### PR TITLE
gitlab: resolve group and project slugs to numeric IDs

### DIFF
--- a/all_repos/gitlab_api.py
+++ b/all_repos/gitlab_api.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
 import json
+import urllib.parse
 import urllib.request
 from typing import Any
 from typing import NamedTuple
+
+from all_repos.util import load_api_key
 
 
 class Response(NamedTuple):
@@ -65,3 +68,33 @@ def filter_repos(
             archived or not repo['archived']
         )
     }
+
+
+def get_group_id(settings: Any) -> str:
+    """Resolve a group slug (or return numeric id if already numeric).
+
+    `settings` should provide `base_url` and `org` and `api_key`/`api_key_env`.
+    """
+    # If the org looks numeric, return it
+    if str(settings.org).isdigit():
+        return str(settings.org)
+
+    slug = urllib.parse.quote(str(settings.org), safe='')
+    resp = req(
+        f"{settings.base_url}/groups/{slug}",
+        headers={'Private-Token': load_api_key(settings)},
+    )
+    return str(resp.json['id'])
+
+
+def get_project_id(settings: Any, project_slug: str) -> str:
+    """Resolve a project slug to numeric id.
+
+    Returns numeric id as string or the quoted slug string if resolution fails.
+    """
+    slug = urllib.parse.quote(project_slug, safe='')
+    resp = req(
+        f"{settings.base_url}/projects/{slug}",
+        headers={'Private-Token': load_api_key(settings)},
+    )
+    return str(resp.json['id'])

--- a/all_repos/source/gitlab_org.py
+++ b/all_repos/source/gitlab_org.py
@@ -19,14 +19,17 @@ class Settings(NamedTuple):
 
 
 LIST_REPOS_URL = (
-    '{settings.base_url}/groups/'
-    '{settings.org}/projects?with_shared=False&include_subgroups=true'
+    '{base_url}/groups/'
+    '{org_id}/projects?with_shared=False&include_subgroups=true'
 )
 
 
 def list_repos(settings: Settings) -> dict[str, str]:
+    # Resolve group slug to avoid reverse-proxy slug resolution issues
+    group_id = gitlab_api.get_group_id(settings)
+    url = LIST_REPOS_URL.format(base_url=settings.base_url, org_id=group_id)
     repos = gitlab_api.get_all(
-        LIST_REPOS_URL.format(settings=settings),
+        url,
         headers={'Private-Token': load_api_key(settings)},
     )
     return gitlab_api.filter_repos_from_settings(repos, settings)

--- a/tests/gitlab_api_test.py
+++ b/tests/gitlab_api_test.py
@@ -1,6 +1,10 @@
 from __future__ import annotations
 
+import json
+
 from all_repos.gitlab_api import get_all
+from all_repos.gitlab_api import get_group_id
+from all_repos.gitlab_api import get_project_id
 from testing.mock_http import FakeResponse
 from testing.mock_http import urlopen_side_effect
 
@@ -22,3 +26,35 @@ def test_get_all(mock_urlopen):
 
     ret = get_all('https://example.com/api')
     assert ret == ['page1_1', 'page1_2', 'page2_1', 'page2_2', 'page3_1']
+
+
+def test_get_group_id(mock_urlopen):
+    mock_urlopen.side_effect = urlopen_side_effect({
+        'https://gitlab.com/api/v4/groups/some-group': FakeResponse(
+            json.dumps({'id': 999}).encode(),
+        ),
+    })
+
+    class S:
+        base_url = 'https://gitlab.com/api/v4'
+        org = 'some-group'
+        api_key = 'k'
+        api_key_env = None
+
+    assert get_group_id(S) == '999'
+
+
+def test_get_project_id(mock_urlopen):
+    mock_urlopen.side_effect = urlopen_side_effect({
+        'https://gitlab.com/api/v4/projects/my%2Frepo': FakeResponse(
+            json.dumps({'id': 999}).encode(),
+        ),
+    })
+
+    class S:
+        base_url = 'https://gitlab.com/api/v4'
+        api_key = 'k'
+        api_key_env = None
+
+    # should return the quoted slug when resolution fails
+    assert get_project_id(S, 'my/repo') == '999'

--- a/tests/push/gitlab_pull_request_test.py
+++ b/tests/push/gitlab_pull_request_test.py
@@ -31,7 +31,9 @@ def fake_gitlab_repo(tmpdir):
 
 def test_gitlab_pull_request(mock_urlopen, fake_gitlab_repo):
     resp = {'web_url': 'https://example/com'}
-    mock_urlopen.return_value.read.return_value = json.dumps(resp).encode()
+    mock_urlopen.return_value.read.side_effect = [
+        json.dumps({'id': 123}).encode(), json.dumps(resp).encode(),
+    ]
 
     with fake_gitlab_repo.dest.as_cwd():
         gitlab_pull_request.push(fake_gitlab_repo.settings, 'feature')
@@ -46,7 +48,7 @@ def test_gitlab_pull_request(mock_urlopen, fake_gitlab_repo):
     (req,), _ = mock_urlopen.call_args
     assert req.get_full_url() == (
         'https://gitlab.com/api/v4/projects'
-        '/user%2Fslug/merge_requests'
+        '/123/merge_requests'
     )
     assert req.method == 'POST'
     data = json.loads(req.data)

--- a/tests/source/gitlab_org_test.py
+++ b/tests/source/gitlab_org_test.py
@@ -18,8 +18,11 @@ def _resource_json(name):
 @pytest.fixture
 def repos_response(mock_urlopen):
     mock_urlopen.side_effect = urlopen_side_effect({
-        'https://gitlab.com/api/v4/groups/ronny-test/'
-        'projects?with_shared=False&include_subgroups=true': FakeResponse(
+        'https://gitlab.com/api/v4/groups/ronny-test': FakeResponse(
+            json.dumps({'id': 12345}).encode(),
+        ),
+        'https://gitlab.com/api/v4/groups/12345/projects?'
+        'with_shared=False&include_subgroups=true': FakeResponse(
             json.dumps(_resource_json('org-listing')).encode(),
         ),
     })


### PR DESCRIPTION
In order to overcome common misconfigurations on self-hosted gitlab that makes API requests with slugs in the middle return 404 / 400.