### PR TITLE
gitlab: escape organization name in GitLab API URLs so we could use nested namespaces

### DIFF
--- a/all_repos/source/gitlab_org.py
+++ b/all_repos/source/gitlab_org.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import urllib.parse
 from typing import NamedTuple
 
 from all_repos import gitlab_api
@@ -19,14 +20,15 @@ class Settings(NamedTuple):
 
 
 LIST_REPOS_URL = (
-    '{settings.base_url}/groups/'
-    '{settings.org}/projects?with_shared=False&include_subgroups=true'
+    '{base_url}/groups/'
+    '{org}/projects?with_shared=False&include_subgroups=true'
 )
 
 
 def list_repos(settings: Settings) -> dict[str, str]:
+    org_escaped = urllib.parse.quote(settings.org, safe='')
     repos = gitlab_api.get_all(
-        LIST_REPOS_URL.format(settings=settings),
+        LIST_REPOS_URL.format(base_url=settings.base_url, org=org_escaped),
         headers={'Private-Token': load_api_key(settings)},
     )
     return gitlab_api.filter_repos_from_settings(repos, settings)


### PR DESCRIPTION
Solutions for 2 problems I encountered when using this project with GitLab.

Explanation in the commit messages